### PR TITLE
fix: make kpi cards grid responsive for mobile view

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -69,7 +69,7 @@ const HomePage = () => {
   return (
     <section>
       <ContentHeader title="Dashboard" subtitle="Welcome back — here's the archive status" />
-      <div className="grid grid-cols-4 gap-3 mb-5">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
         {isLoadingStats
           ? <>
             <StatCardSkeleton />


### PR DESCRIPTION
### Improved responsiveness of the dashboard page

**Changes**

- Added responsiveness across mobile and larger sized screen to the KPI cards grid 

### Previews

**Before**

<img width="1180" height="1688" alt="localhost_3000_dashboard (1)" src="https://github.com/user-attachments/assets/b4a5c92a-9630-44b4-8603-bc1aeac1793e" />

**After**

<img width="1180" height="1688" alt="localhost_3000_dashboard" src="https://github.com/user-attachments/assets/f572555d-6f55-413c-9201-872fcea949a1" />
